### PR TITLE
Update to Hyperapp 1.0

### DIFF
--- a/_posts/2017-03-17-1.md
+++ b/_posts/2017-03-17-1.md
@@ -1,36 +1,33 @@
 ---
 layout: post
-title: 超軽量Viewライブラリ「HyperApp」の日本語ドキュメント風の何か
-outline: WebフロントエンドのViewライブラリといえばReactやVueといった高機能なものが主流ですが、もっと手軽で最小限なライブラリが欲しいことありませんか？ それに応えるのがHyperAppです。個人的に気になってたのでドキュメントを意訳してみました。
-categories: [JavaScript, HyperApp]
+title: 超軽量Viewライブラリ「Hyperapp」の日本語ドキュメント風の何か
+outline: WebフロントエンドのViewライブラリといえばReactやVueといった高機能なものが主流ですが、もっと手軽で最小限なライブラリが欲しいことありませんか？ それに応えるのがHyperappです。個人的に気になってたのでドキュメントを意訳してみました。
+categories: [JavaScript, Hyperapp]
 ---
 
 ### Introduction
 
-[HyperApp - GitHub](https://github.com/hyperapp/hyperapp)
+[Hyperapp - GitHub](https://github.com/hyperapp/hyperapp)
 
-> HyperApp is a JavaScript library for building frontend applications.
+> Hyperapp is a JavaScript library for building web applications.
 
-HyperAppはWebアプリケーションのフロント(主にView)を担うJavaScript用のライブラリです。このライブラリは3つのコンセプトで成り立っています。
+Hyperapp は Web アプリケーションのフロント(主に View)を担う JavaScript 用のライブラリです。このライブラリは 3 つのコンセプトで成り立っています。
 
-* 外部ライブラリに依存しない、超軽量**1KB**のライブラリ
+* 外部ライブラリに依存しない、超軽量**1KB**ぐらいのライブラリ
 * ステートレスコンポーネント
 * Elm Architecture に則ったスケーラブル可能な仕組み
 
-今回はHyperAppの[Wiki](https://github.com/hyperapp/hyperapp/wiki)及び周辺のドキュメント[^1]を勝手に意訳[^2]してみようと思います😌💡
+今回は Hyperapp の[ドキュメント](https://github.com/hyperapp/hyperapp/blob/master/docs/README.md#documentation)を勝手に意訳[^1]してみようと思います 😌💡
 
-[^1]: 執筆時点(2017/03/17)でのREADME, wikiを参考にしています。
-[^2]: 英語が得意でない者が雰囲気で訳したものです。本家HyperAppとは無関係の個人的な記事です。
+[^1]: 英語が得意でない者が雰囲気で訳したものです。本家 Hyperapp とは無関係の個人的な記事です。
 
-* TOC
-{:toc}
+* TOC {:toc}
 
+### Getting Started
 
-### [Getting Started](https://github.com/hyperapp/hyperapp/wiki/Getting-Started)
+Hyperapp は器用に作られたもので、新規プロダクトに取り入れることはもちろん、既存の Web アプリケーションに組み込むこともできるよ。
 
-HyperAppは器用に作られたもので、新規プロダクトに取り入れることはもちろん、既存のWebアプリケーションに組み込むこともできるよ。
-
-一番簡単な方法は何と言ってもCDNだね。
+一番簡単な方法は何と言っても CDN だね。
 
 ```html
 <script src="https://unpkg.com/hyperapp"></script>
@@ -39,15 +36,16 @@ HyperAppは器用に作られたもので、新規プロダクトに取り入れ
 バージョンを指定したいかな？ そんなときはこう。
 
 ```html
-<script src="https://unpkg.com/hyperapp@0.7.0"></script>
+<script src="https://unpkg.com/hyperapp@1.0.1"></script>
 ```
 
 #### こんにちは世界
 
-ではさっそくHyperAppを使って「こんにちは世界」を表示させてみよう。`index.html`を用意して以下のコードをコピペしてブラウザで見てみよう😄  
-HyperAppでは[JSX](https://github.com/hyperapp/hyperapp/wiki/JSX)をつかった記法と、ES6のテンプレートリテラルを使った[Hyperx](https://github.com/hyperapp/hyperapp/wiki/Hyperx)という記法の2つが使えるよ。How wonderful!! それぞれのコード例を用意したから好きな方を使ってね。
+ではさっそく Hyperapp を使って「こんにちは世界」を表示させてみよう。`index.html`を用意して以下のコードをコピペしてブラウザで見てみよう 😄
 
-##### JSXで書いた場合
+Hyperapp では JSX をつかった記法と、ES6 のテンプレートリテラルを使った Hyperx という記法の２つが使えるよ。How wonderful!! それぞれのコード例を用意したから好きな方を使ってね。
+
+##### JSX で書いた場合
 
 ```html
 <body>
@@ -58,16 +56,19 @@ HyperAppでは[JSX](https://github.com/hyperapp/hyperapp/wiki/JSX)をつかっ�
   const { h, app } = hyperapp
   /** @jsx h */
 
-  app({
-    model: "こんにちは世界",
-    view: model => <h1 id="title">{model}</h1>
-  })
+  const state = {
+    greeting: "こんにちは世界"
+  }
+  const actions = {}
+  const view = state => <h1 id="title">{state.greeting}</h1>
+
+  app(state, actions, view, document.body)
 
   </script>
 </body>
 ```
 
-##### Hyperxで書いた場合
+##### Hyperx で書いた場合
 
 ```html
 <body>
@@ -78,32 +79,34 @@ HyperAppでは[JSX](https://github.com/hyperapp/hyperapp/wiki/JSX)をつかっ�
   const { h, app } = hyperapp
   const html = hyperx(h)
 
-  app({
-    model: "こんにちは世界",
-    view: model => html`<h1>${model}</h1>`
-  })
+  const state = {
+    greeting: "こんにちは世界"
+  }
+  const actions = {}
+  const view = state => htm`<h1 id="title">{state.greeting}</h1>`
+
+  app(state, actions, view, document.body)
 
   </script>
 </body>
 ```
 
 さて、ブラウザでは何が起きたかな？  
-ブラウザはHyperxやJSXをCDN経由でダウンロードし、scriptの部分をコンパイルして描画したよ。
+ブラウザは Hyperx や JSX を CDN 経由でダウンロードし、script の部分をコンパイルして描画したよ。
 
-この例ではHyperAppとは何かを手軽に知ることができたと思うけれど、これだけだとWebアプリケーション開発の例としては少々物足りないよね。わかるよ。
+この例では Hyperapp とは何かを手軽に知ることができたと思うけれど、これだけだと Web アプリケーション開発の例としては少々物足りないよね。わかるよ。
 
-では、次にWebpack、Browserify、Rollupをつかったビルド環境のセットアップの例を見てみよう。
+では、次に Webpack、Browserify、Rollup をつかったビルド環境のセットアップの例を見てみよう。
 
+### Build Setup
 
-### [Build Setup](https://github.com/hyperapp/hyperapp/wiki/Build-Setup)
-
-Webアプリケーションの開発環境を用意するには3つの要素が必要なんだ。
+Web アプリケーションの開発環境を用意するには 3 つの要素が必要なんだ。
 
 * パッケージマネージャ([npm](https://www.npmjs.com/), [yarn](https://yarnpkg.com/lang/en/))
 * コンパイラ([babel](http://babeljs.io/), [Bublé](https://buble.surge.sh/guide/))
 * バンドラ([Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/), [Rollup](http://rollupjs.org/))
 
-なぜこれらが必要かというと、JSX/Hyperxで書かれたソースをコンパイルするためなんだ💪 コンパイルされると、HyperAppの [h](https://github.com/hyperapp/hyperapp/wiki/reference#h)関数という**仮想DOMを生成するための関数**になるのだけれど、それについてはまた後で語るからね。
+なぜこれらが必要かというと、JSX/Hyperx で書かれたソースをコンパイルするためなんだ 💪 コンパイルされると、HyperApp の `h` 関数という**仮想 DOM を生成するための関数**になるのだけれど、それについてはまた後で語るからね。
 
 コンパイル前(JSX/Hyperx)
 
@@ -118,22 +121,20 @@ h("h1", { id: "test" }, "Hi.")
 ```
 
 こんな具合だよ。いい具合だね。  
-さぁ次の章ではJSXとHyperx各々のためのビルド環境のセットアップを学ぶよ。ついておいで！
+さぁ次の章では JSX と Hyperx 各々のためのビルド環境のセットアップを学ぶよ。ついておいで！
 
+### JSX を使う環境の用意
 
-### [JSXを使う環境の用意](https://github.com/hyperapp/hyperapp/wiki/JSX)
+JSX は XML と同様データの記法のひとつだよ。知ってたかい？ これを使うことで HTML(テンプレート)と JavaScript(処理)を一つのファイルに混在させることができるよ。
 
-JSXはXMLと同様データの記法のひとつだよ。知ってたかい？ これを使うことでHTML(テンプレート)とJavaScript(処理)を一つのファイルに混在させることができるよ。
+JSX を使うには上述の通りコンパイルが必要なんだ。JSX を `h` 関数に変換し、ひとつの js ファイルにバンドルし、配信しなければならないからね。ではさっそくビルド環境の用意をしよう。
 
-
-JSXを使うには上述の通りコンパイルが必要なんだ。JSXをh関数に変換し、ひとつのjsファイルにバンドルし、配信しなければならないからね。ではさっそくビルド環境の用意をしよう。
-
-#### Browserifyを使う場合
+#### Browserify を使う場合
 
 ##### 必要なモジュールのインストール
 
 ```shell
-$ npm install -S hyperapp
+$ npm install hyperapp
 
 $ npm install -D babel-plugin-transform-react-jsx babel-preset-es2015 babelify browserify bundle-collapser uglifyify uglifyjs
 ```
@@ -143,14 +144,14 @@ $ npm install -D babel-plugin-transform-react-jsx babel-preset-es2015 babelify b
 ```json
 {
   "presets": ["es2015"],
-    "plugins": [
-      [
-        "transform-react-jsx",
-        {
-          "pragma": "h"
-        }
-      ]
+  "plugins": [
+    [
+      "transform-react-jsx",
+      {
+        "pragma": "h"
+      }
     ]
+  ]
 }
 ```
 
@@ -163,12 +164,12 @@ $(npm bin)/browserify \
   -p bundle-collapser/plugin index.js | uglifyjs > bundle.js
 ```
 
-#### Webpackを使う場合
+#### Webpack を使う場合
 
 ##### 必要なモジュールのインストール
 
 ```shell
-$ npm install -S hyperapp
+$ npm install hyperapp
 
 $ npm install -D webpack babel-core babel-loader babel-preset-es2015 babel-plugin-transform-react-jsx
 ```
@@ -178,14 +179,14 @@ $ npm install -D webpack babel-core babel-loader babel-preset-es2015 babel-plugi
 ```json
 {
   "presets": ["es2015"],
-    "plugins": [
-      [
-        "transform-react-jsx",
-        {
-          "pragma": "h"
-        }
-      ]
+  "plugins": [
+    [
+      "transform-react-jsx",
+      {
+        "pragma": "h"
+      }
     ]
+  ]
 }
 ```
 
@@ -195,14 +196,16 @@ $ npm install -D webpack babel-core babel-loader babel-preset-es2015 babel-plugi
 module.exports = {
   entry: "./index.js",
   output: {
-    filename: "bundle.js",
+    filename: "bundle.js"
   },
   module: {
-    loaders: [{
-      test: /\.js$/,
-      exclude: /node_modules/,
-      loader: "babel-loader"
-    }]
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: "babel-loader"
+      }
+    ]
   }
 }
 ```
@@ -213,12 +216,12 @@ module.exports = {
 $(npm bin)/webpack -p
 ```
 
-#### Rollupを使う場合
+#### Rollup を使う場合
 
 ##### 必要なモジュールのインストール
 
 ```shell
-$ npm install -S hyperapp
+$ npm install hyperapp
 
 $ npm install -D rollup rollup-plugin-babel rollup-plugin-node-resolve rollup-plugin-uglify babel-preset-es2015-rollup babel-plugin-transform-react-jsx
 ```
@@ -235,9 +238,7 @@ export default {
     babel({
       babelrc: false,
       presets: ["es2015-rollup"],
-      plugins: [
-        ["transform-react-jsx", { pragma: "h" }]
-      ]
+      plugins: [["transform-react-jsx", { pragma: "h" }]]
     }),
     resolve({
       jsnext: true
@@ -253,181 +254,147 @@ export default {
 $(npm bin)/rollup -cf iife -i index.js -o bundle.js
 ```
 
+### Hyperx を使う環境の用意
 
+JSX のときとインストールするファイルが少々変わるだけなので割愛するよ 😌
 
-### [Hyperxを使う環境の用意](https://github.com/hyperapp/hyperapp/wiki/Hyperx)
+### API Reference
 
-JSXのときとインストールするファイルが少々変わるだけなので割愛するよ😌
+ここでは Hyperapp のモジュールや関数の使い方について、サンプルと併せて紹介するよ。
 
+Hyperapp は大きく分けて 3 つの仕組みを提供しているんだ。
 
-### [API Reference](https://github.com/hyperapp/hyperapp/wiki/Reference)
+* `h 関数` … 仮想 DOM を生成する関数
+* `app 関数` … Hyperapp を利用した Application を実行する関数
 
-ここではHyperAppのモジュールや関数の使い方について、サンプルと併せて紹介するよ。
+#### `h`
 
-HyperAppは大きく分けて3つの仕組みを提供しているんだ。
-
-* `h 関数` … 仮想DOMを生成する関数
-* `app 関数` … HyperAppを利用したApplicationを実行する関数
-* `Router プラグイン` … ルータ機能群
-
-
-####  [h](https://github.com/hyperapp/hyperapp/wiki/reference#h)
-
-仮想DOMを返す関数だよ。ここで言う仮想DOMとは、ネストされたDOMのツリーをJavaScriptのオブジェクトとして表現しているものだよ🌴
+仮想 DOM を返す関数だよ。ここで言う仮想 DOM とは、ネストされた DOM のツリーを JavaScript のオブジェクトとして表現しているものだよ 🌴
 
 Syntax
 
 ```js
-h(tag, data, children);
+h(name, props, children)
 ```
 
-* `tag {String}` … 「div」など、HTML上でのタグ名
-* `data {Object}` … Elementに挿入されるattributes
+* `name {String}` … 「div」など、HTML 上でのタグ名
+* `props {Object}` … Element に挿入される attributes
 * `children {String | Array}` … 子要素
 
 ```js
-h('a', {href: '#'}, 'next page');
+h("a", { href: "#" }, "next page")
 
 // return object
 // {
-//   tag: 'a',
-//   data: {
+//   name: 'a',
+//   props: {
 //     href: '#'
 //   },
 //   children: 'next page'
 // }
 ```
 
+#### `app`
 
-#### [app](https://github.com/hyperapp/hyperapp/wiki/reference#app)
-
-HyperAppによるWebアプリケーションを起動するよ。これを呼び出すことで全てが始まる。オプションを添えられるよ。
+Hyperapp による Web アプリケーションを起動するよ。これを呼び出すことで全てが始まる。オプションを添えられるよ。
 
 ```js
-app({
-  model,
-  view,
-  actions,
-  subscriptions,
-  plugins,
-  root
-});
+app(state, actions, view, container)
 ```
 
-#### [model](https://github.com/hyperapp/hyperapp/wiki/reference#-model-)
+#### State
 
-アプリケーションのStateを管理するオブジェクトだよ。primitiveな値でも、配列でも、Objectでもいいよ。
+アプリケーションの State を管理するオブジェクトだよ。Object でないとダメだよ！
 
-#### [view](https://github.com/hyperapp/hyperapp/wiki/reference#-view-)
+#### View
 
-仮想DOMを返す関数だよ。引数に`model`と`actions`をとるよ。
+仮想 DOM を返す関数だよ。引数に`state`と`actions`をとるよ。
 
 ```js
-app({
-  model: true,
-  actions: {
-    toggle: model => !model,
-  },
-  view: (model, actions) =>
-    <button onClick={actions.toggle}>
-      {model.toString()}
+const state = {
+  on: true
+}
+
+const actions = {
+  toggle: () => state => ({ on: !state.on })
+}
+
+const view = (state, actions) => (
+  <button onclick={actions.toggle}>{state.on.toString()}</button>
+)
+
+app(state, actions, view, document.body)
+```
+
+#### Actions
+
+Web アプリケーションの振る舞いを定義する関数のコレクションだよ。`actions`は一般的に`state`を更新するために利用されるよ。そのため、返り値が新しい`state`であることがしばしば。
+
+```js
+const actions = {
+  setValue: value => ({ value }),
+  addValue: value => state => ({ value: state.value + value }),
+  addValueLater: value => (state, actions) => {
+    setTimeout(() => {
+      actions.addValue(value)
+    }, 1000)
+  }
+}
+```
+
+* `data` … action の処理(モデルの更新)に必要な情報
+* `state` … 現在の state
+* `actions` … アプリケーションが持つ大元の actions
+
+```js
+const state = { count: 0 }
+const actions = {
+  sub: () => state => state - 1,
+  add: () => state => state + 1
+}
+
+const view = (state, actions) => (
+  <div>
+    <h1>{state.count}</h1>
+    <button onclick={actions.sub} disabled={state.count <= 0}>
+      -
     </button>
-});
+    <button onclick={actions.add}>+</button>
+  </div>
+)
+
+app(state, actions, view, document.body)
 ```
 
-#### [actions](https://github.com/hyperapp/hyperapp/wiki/reference#-actions-)
+#### Global Events
 
-Webアプリケーションの振る舞いを定義する関数のコレクションだよ。`actions`は一般的に`model`を更新するために利用されるよ。そのため、返り値が新しい`model`であることがしばしば。
-
-引数は4つだよ。
-
-* `model` … 現在のmodel
-* `data` … actionの処理(モデルの更新)に必要な情報
-* `actions` … アプリケーションが持つ大元のactions
-* `error` … エラー時に呼ばれるコールバック
+app 関数が返すオブジェクトに state と繋がっている元の actions がある。view に渡される actions と同じで、action を呼び出す時に、state が更新される！
 
 ```js
-app({
-  model: 0,
-  actions: {
-    add: model => model + 1,
-    sub: model => model - 1,
-  },
-  view: (model, actions) =>
-    <div>
-      <button onClick={actions.add}>
-        +
-      </button>
-      <h1>{model}</h1>
-      <button onClick={actions.sub}
-        disabled={model <= 0}>
-        -
-      </button>
-    </div>
-});
+const state = { x: 0, y: 0 }
+const actions = {
+  move: () => ({ x, y }) => ({ x, y })
+}
+const view = state => <h1>{state.x + ", " + state.y}</h1>
+
+const MyApp = app(state, actions, view, document.body)
+
+addEventListener("mousemove", e =>
+  MyApp.move({
+    x: e.clientX,
+    y: e.clientY
+  })
+)
 ```
 
-#### [subscriptions](https://github.com/hyperapp/hyperapp/wiki/reference#-subscriptions-)
+#### [Lifecycle Methods](https://github.com/hyperapp/hyperapp/blob/master/docs/concepts/lifecycle-events.md)
 
-`DOMContentLoaded`時に一度だけ発火される関数をもつ配列だよ。
+仮想 DOM のライフサイクルにまつわるイベントをハンドリングできるよ。
 
-```js
-app({
-  model: { x: 0, y: 0 },
-  actions: {
-    move: (_, { x, y }) => ({ x, y })
-  },
-  subscriptions: [
-    (_, actions) =>
-      addEventListener("mousemove",
-        e => actions.move({
-          x: e.clientX,
-          y: e.clientY,
-        })
-      )
-  ],
-  view: model => <h1>{model.x + ", " + model.y}</h1>
-});
-```
-
-
-#### [Router](https://github.com/hyperapp/hyperapp/wiki/reference#Router)
-
-`view`に、PathをKeyにTemplateを登録するとルーティングが行えるよ。SPAになるよ😘 
-
-```js
-app({
-  view: {
-    "/": (model, actions) =>
-      <div>
-        <h1>Home</h1>
-        <button
-          onclick={_ => actions.router.go("/about")}>
-          About
-        </button>
-      </div>,
-
-    "/about": (model, actions) =>
-      <div>
-        <h1>About</h1>
-        <button
-          onclick={_ => actions.router.go("/")}>
-          Home
-        </button>
-      </div>
-  },
-  plugins: [Router]
-});
-```
-
-
-#### [Lifecycle Methods](https://github.com/hyperapp/hyperapp/wiki/reference#lifecycle-methods)
-
-仮想DOMのライフサイクルにまつわるイベントをハンドリングできるよ。
-
-* `onCreate` … ElementがDOMとして構築されたとき
-* `onUpdate` … Elementの要素が更新されたとき
-* `onRemove` … ElementがDOMから消える直前
+* [`oncreate`](https://github.com/hyperapp/hyperapp/blob/master/docs/concepts/lifecycle-events.md#oncreate) … Element が DOM として構築されたとき
+* [`onupdate`](https://github.com/hyperapp/hyperapp/blob/master/docs/concepts/lifecycle-events.md#onupdate) … Element の要素が更新されたとき
+* [`onremove`](https://github.com/hyperapp/hyperapp/blob/master/docs/concepts/lifecycle-events.md#onremove) … Element が DOM から消える直前
+* [`ondestroy`](https://github.com/hyperapp/hyperapp/blob/master/docs/concepts/lifecycle-events.md#ondestroy) … Element が DOM から消える直後
 
 ```js
 const node = document.createElement("div")
@@ -437,40 +404,34 @@ const Editor = options => {
   const setOptions = options =>
     Object.keys(options).forEach(key => editor.setOption(key, options[key]))
 
-  const onCreate = elm => {
+  const oncreate = elm => {
     setOptions(options)
     elm.appendChild(node)
   }
 
-  const onUpdate = _ => setOptions(options)
+  const onupdate = _ => setOptions(options)
 
-  return <div onCreate={onCreate} onUpdate={onUpdate}></div>
+  return <div oncreate={oncreate} onupdate={onupdate} />
 }
 ```
-
-
 
 ### Afterword
 
 良さそうなところ
 
-* 小さな開発用ツールなどをつくるときには高速で実装できるし、実行速度的にも◎
-* 特にReactでJSX使ってた人はとっつきやすいかも
-* 小さなライブラリなので、初めてのOSSコードリーディングにはもってこい
-* 同じく、初めてのOSSコントリビュートにはもってこい(？)
+* 小さな開発用ツールなどをつくるときには高速で実装できるし、実行速度的にも ◎
+* 特に React で JSX 使ってた人はとっつきやすいかも
+* 小さなライブラリなので、初めての OSS コードリーディングにはもってこい
+* 同じく、初めての OSS コントリビュートにはもってこい(？)
 
 ちょっと考えものなところ
 
 * テンプレートファイルを外出しできないとマークアップエンジニアとの分業がしにくいかも
 * もう少し細かい単位でライフサイクルのイベントハンドリングをしたくなるかも
-* viewの共通部品の定義(Abstract的なもの)とか欲しくなりそう
-* SSR対応できる？
+* view の共通部品の定義(Abstract 的なもの)とか欲しくなりそう
 
-一部訳すのをさぼりました。すみません😵
+一部訳すのをさぼりました。すみません 😵
 
-初めて翻訳(の真似事)をしたのですが、自然と海外ドキュメンタリーの吹き替えみたいな声が脳内再生されました。「[私ゃ失敗こいちまってさ](http://shirobako-anime.com/story/04.html)」的なやつです。ともあれ、とても楽しかったですしHyperAppを好きになれて満足しました。
+初めて翻訳(の真似事)をしたのですが、自然と海外ドキュメンタリーの吹き替えみたいな声が脳内再生されました。「[私ゃ失敗こいちまってさ](http://shirobako-anime.com/story/04.html)」的なやつです。ともあれ、とても楽しかったですし Hyperapp を好きになれて満足しました。
 
-間違いや指摘箇所があれば[@aloerina_](https://twitter.com/aloerina_)までご連絡ください。
-
-
-
+間違いや指摘箇所があれば[@aloerina\_](https://twitter.com/aloerina_)までご連絡ください。


### PR DESCRIPTION
Hi! @aloerina01! 👋 

* Changed the case ~~HyperApp~~ → **Hyperapp**.
* Updated the code examples to use the 1.0 API.
* Removed `subscriptions` section that we don't have anymore.
* Removed  `router` section now that the router is a different package.
* Removed dead links to documentation that does not exist anymore.
* Hyperapp now supports SSR re-hydration by default so I removed your comment about SSR.

Most of these changes are cosmetic and I didn't touch anything else. 